### PR TITLE
Fixed Google AMP error & Widget improvements

### DIFF
--- a/inc/widget-layouts/style 1.php
+++ b/inc/widget-layouts/style 1.php
@@ -55,12 +55,22 @@
 						?>
 					<p class="wppr-style1-buttons">
 						<?php
-							$link   = "<a href='{$affiliate_link}' rel='nofollow' target='_blank' class='wppr-bttn'>" . __( $instance['cwp_tp_buynow'], 'cwppos' ) . '</a>';
+						$site = get_site_url();
+						$find = '/';
+						$replace = '\/';
+						$site = str_replace( $find, $replace, $site );
+						if(preg_match( '/'.$site.'/', $affiliate_link)) {
+							$target = "target='_self'";
+						} else {
+							$target = "target='_blank'";
+						}
+
+							$link   = "<a href='{$affiliate_link}' rel='nofollow' {$target} class='wppr-bttn'>" . __( $instance['cwp_tp_buynow'], 'cwppos' ) . '</a>';
 						if ( ! empty( $instance['cwp_tp_buynow'] ) ) {
 							echo apply_filters( 'wppr_widget_style1_buynow_link', $link, get_the_ID(), $affiliate_link, $instance['cwp_tp_buynow'] );
 						}
 
-							$link   = "<a href='{$review_link}' rel='nofollow' target='_blank' class='wppr-bttn'>" . __( $instance['cwp_tp_readreview'], 'cwppos' ) . '</a>';
+							$link   = "<a href='{$review_link}' rel='nofollow' class='wppr-bttn'>" . __( $instance['cwp_tp_readreview'], 'cwppos' ) . '</a>';
 						if ( ! empty( $instance['cwp_tp_readreview'] ) ) {
 							echo apply_filters( 'wppr_widget_style1_readreview_link', $link, get_the_ID(), $review_link, $instance['cwp_tp_readreview'] );
 						}

--- a/inc/wppr-main.php
+++ b/inc/wppr-main.php
@@ -155,7 +155,7 @@ function cwppos_show_review( $id = '', $visual = 'full' ) {
 		if ( $visual == 'full' || $visual == 'yes' ) {
 			$extra_class = $visual == 'yes' ? 'cwp-chart-embed' : '';
 			$return_string .= '<div class="cwp-review-chart ' . $extra_class . '">
-                                    <meta itemprop="datePublished" datetime="' . get_the_time( 'Y-m-d', $id ) . '">';
+                                    <meta itemprop="datePublished" content="' . get_the_time( 'Y-m-d', $id ) . '">';
 			if ( cwppos( 'cwppos_infl_userreview' ) != 0 && $commentNr > 1 ) {
 				$return_string .= '<div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating" class="cwp-review-percentage" data-percent="';
 				$return_string .= $rating['overall'] . '"><span itemprop="ratingValue" class="cwp-review-rating">' . $divrating . '</span><meta itemprop="bestRating" content = "10"/>


### PR DESCRIPTION
Using content in itemprop="datepublished" because datetime wasn't accepted by Google AMP. Content is recommended to use. Fixes https://github.com/Codeinwp/wp-product-review/issues/143