### PR TITLE
Revert "Template 2 shows empty stars (with a PHP notice if debug is enabled)"

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -83,7 +83,6 @@ if ( ! function_exists( 'wppr_display_rating_custom_icon' ) ) {
 	 * Display the custom icon rating.
 	 */
 	function wppr_display_rating_custom_icon( $template, $review_object ) {
-		$review_rating = $review_object->get_rating();
 		?>
 		<div id="review-statistics">
 			<div class="review-wu-bars">


### PR DESCRIPTION
Reverts Codeinwp/wp-product-review#323