### PR TITLE
UI for .rev-wu-image improved [Lite version]

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -281,8 +281,14 @@
 	vertical-align: middle;
 }
 
+#review-statistics .review-wrap-up .review-wu-left .rev-wu-image:hover {
+	background: rgb(238, 238, 238);
+	transition: all, 0.3s
+}
+
 #review-statistics .review-wrap-up .review-wu-left .rev-wu-image a {
 	display: inline-block;
+	box-shadow: none !important; 
 }
 
 #review-statistics .review-wrap-up .review-wu-left .rev-wu-image img {

--- a/dist/assets/css/default.css
+++ b/dist/assets/css/default.css
@@ -281,8 +281,14 @@
 	vertical-align: middle;
 }
 
+#review-statistics .review-wrap-up .review-wu-left .rev-wu-image:hover {
+	background: rgb(238, 238, 238);
+	transition: all, 0.3s
+}
+
 #review-statistics .review-wrap-up .review-wu-left .rev-wu-image a {
 	display: inline-block;
+	box-shadow: none !important; 
 }
 
 #review-statistics .review-wrap-up .review-wu-left .rev-wu-image img {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-helpscout-faq": "~0.1.0",
-    "request": "^2.83.0",
     "grunt-plugin-fleet": "codeinwp/grunt-plugin-fleet",
-    "load-project-config": "~0.2.0"
+    "load-project-config": "~0.2.0",
+    "request": "^2.83.0"
   },
   "wraithSlug": [
     "wp-product-review"


### PR DESCRIPTION
Getting rid of that **ugly transitioning border-bottom**, just tweaked some css to **transition background instead**.

See the change:

| BEFORE...                                                                                                           | AFTER...                                                                                                            |
|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| ![old design](https://user-images.githubusercontent.com/25429790/47298702-11cc9b80-d636-11e8-818d-7411542a34c8.gif) | ![new design](https://user-images.githubusercontent.com/25429790/47298717-198c4000-d636-11e8-84a1-c29f853fdcd1.gif) |

THIS CHANGE JUST REFLECTS INTO THE DEFAULT TEMPLATE.